### PR TITLE
feat: pass accept language header to backend

### DIFF
--- a/src/API/response.ts
+++ b/src/API/response.ts
@@ -1,6 +1,7 @@
 import { getToken } from '../context/authContext';
 import { Request, RequestMethod, Response } from './types';
 import { ResponseErrors } from './responseErrors';
+import { Locale } from '../utils/locale';
 
 const BASE_URL = process.env.REACT_APP_API_BASE_URL;
 
@@ -21,6 +22,7 @@ export const getResponse = async <T>({ url, method, body }: Request): Promise<Re
     headers: {
       'Content-Type': 'application/json',
       'X-TOKEN': getToken(),
+      'Accept-Language': Locale.currentLocale,
     },
     method: method || RequestMethod.GET,
     body: JSON.stringify(body),

--- a/src/components/languages/languagesManager.ts
+++ b/src/components/languages/languagesManager.ts
@@ -1,23 +1,24 @@
 import { useState } from 'react';
 import { LOCALES } from './locales';
 import { enUS, ru } from 'date-fns/locale';
+import { Locale } from '../../utils/locale';
 
+function getInitialLocal() {
+  const savedLocale = localStorage.getItem('locale');
+  return savedLocale || LOCALES.ENGLISH;
+}
+
+const fnsLocales = {
+  'ru-RU': ru,
+  'en-US': enUS,
+};
 
 export const LanguagesManager = () => {
   const [currentLocale, setCurrentLocale] = useState(getInitialLocal());
+  Locale.currentLocale = currentLocale;
   const setLocale = (locale: string) => {
     setCurrentLocale(locale);
     localStorage.setItem('locale', locale);
-  };
-
-  function getInitialLocal() {
-    const savedLocale = localStorage.getItem('locale');
-    return savedLocale || LOCALES.ENGLISH;
-  }
-
-  const fnsLocales = {
-    'ru-RU': ru,
-    'en-US': enUS,
   };
 
   const fnsLocale = fnsLocales[currentLocale as keyof typeof fnsLocales] || enUS;

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,0 +1,5 @@
+export class Locale {
+  static readonly DEFAULT_LOCALE = 'en-US';
+
+  static currentLocale = Locale.DEFAULT_LOCALE;
+}


### PR DESCRIPTION
- Добавила в вызов апи передачу заголовка с языком, чтобы бек знал на каком языке нужно отдать ответ.